### PR TITLE
Avoid ConcurrentModificationException

### DIFF
--- a/src/main/java/com/zuhlke/ta/prototype/solutions/inmemory/InMemoryTweetStore.java
+++ b/src/main/java/com/zuhlke/ta/prototype/solutions/inmemory/InMemoryTweetStore.java
@@ -13,12 +13,13 @@ public class InMemoryTweetStore implements TweetStore {
     private final List<Tweet> tweets = new ArrayList<>();
 
     @Override
-    public void importTweets(Stream<Tweet> tweets) {
+    public synchronized void importTweets(Stream<Tweet> tweets) {
         this.tweets.addAll(tweets.collect(toList()));
     }
 
     @Override
-    public Stream<Tweet> tweets() {
-        return tweets.stream();
+    public synchronized Stream<Tweet> tweets() {
+        // Make a copy of the tweets so we can still append new ones whilst the analysis is running
+        return new ArrayList<>(tweets).stream();
     }
 }

--- a/src/test/java/com/zuhlke/ta/prototype/solutions/inmemory/InMemoryTweetStoreTest.java
+++ b/src/test/java/com/zuhlke/ta/prototype/solutions/inmemory/InMemoryTweetStoreTest.java
@@ -1,0 +1,25 @@
+package com.zuhlke.ta.prototype.solutions.inmemory;
+
+import com.zuhlke.ta.prototype.Tweet;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class InMemoryTweetStoreTest {
+    @Test
+    public void should_be_able_to_append_new_tweets_whilst_processing() {
+        InMemoryTweetStore target = new InMemoryTweetStore();
+
+        target.importTweets(Stream.of(anyTweet(), anyTweet()));
+
+        target.tweets()
+                .peek(t -> target.importTweets(Stream.of(anyTweet()))) // Whilst iterating the existing items insert new ones
+                .collect(Collectors.toList()); // Should not get a ConcurrentModificationException when collecting
+    }
+
+    private Tweet anyTweet() {
+        return new Tweet(0, "userid", "message", LocalDate.now());
+    }
+}


### PR DESCRIPTION
My bad - avoids ConcurrentModificationException when tweets are being collected whilst processing a query.